### PR TITLE
fix: render of the termsText variable

### DIFF
--- a/src/login/pages/Terms.svelte
+++ b/src/login/pages/Terms.svelte
@@ -32,7 +32,7 @@
   {#snippet headerNode()}
     {@render msg('termsTitle')()}
   {/snippet}
-  <div id="kc-terms-text">{msg('termsText')}</div>
+  <div id="kc-terms-text">{@render msg('termsText')()}</div>
   <form
     class="form-actions"
     action={url.loginAction}


### PR DESCRIPTION
Fixes rendering of `termsText` variable in the Terms page

Closes #3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the display of terms text to support richer and more dynamic content within the terms section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->