### PR TITLE
fix: implement WebAuthn conditional UI (passkeys) on Login.svelte

### DIFF
--- a/src/login/pages/Login.svelte
+++ b/src/login/pages/Login.svelte
@@ -5,8 +5,10 @@
   import { kcSanitize } from 'keycloakify/lib/kcSanitize';
   import { getKcClsx } from 'keycloakify/login/lib/kcClsx';
   import { clsx } from 'keycloakify/tools/clsx';
+  import { untrack } from 'svelte';
   import type { I18n } from '../i18n';
   import type { KcContext } from '../KcContext';
+  import { useScript } from './Login.useScript';
   const {
     kcContext,
     i18n,
@@ -21,12 +23,30 @@
     }),
   );
 
-  const { social, realm, url, usernameHidden, login, auth, registrationDisabled, messagesPerField } =
-    $derived(kcContext);
+  const {
+    social,
+    realm,
+    url,
+    usernameHidden,
+    login,
+    auth,
+    registrationDisabled,
+    messagesPerField,
+    enableWebAuthnConditionalUI,
+    authenticators,
+  } = $derived(kcContext);
 
   const { msg, msgStr } = $derived($i18n);
 
   const [isLoginButtonDisabled, setIsLoginButtonDisabled] = useState(false);
+
+  const webAuthnButtonId = 'authenticateWebAuthnButton';
+
+  useScript({
+    webAuthnButtonId,
+    kcContext: untrack(() => kcContext),
+    i18n: untrack(() => i18n),
+  });
 </script>
 
 <Template
@@ -126,7 +146,7 @@
                 value={login.username ?? ''}
                 type="text"
                 autofocus
-                autocomplete="username"
+                autocomplete={enableWebAuthnConditionalUI ? 'username webauthn' : 'username'}
                 aria-invalid={messagesPerField.existsError('username', 'password')}
               />
               {#if messagesPerField.existsError('username', 'password')}
@@ -225,4 +245,66 @@
       {/if}
     </div>
   </div>
+  {#if enableWebAuthnConditionalUI}
+    <form
+      id="webauth"
+      action={url.loginAction}
+      method="post"
+    >
+      <input
+        type="hidden"
+        id="clientDataJSON"
+        name="clientDataJSON"
+      />
+      <input
+        type="hidden"
+        id="authenticatorData"
+        name="authenticatorData"
+      />
+      <input
+        type="hidden"
+        id="signature"
+        name="signature"
+      />
+      <input
+        type="hidden"
+        id="credentialId"
+        name="credentialId"
+      />
+      <input
+        type="hidden"
+        id="userHandle"
+        name="userHandle"
+      />
+      <input
+        type="hidden"
+        id="error"
+        name="error"
+      />
+    </form>
+
+    {#if authenticators !== undefined && authenticators.authenticators.length !== 0}
+      <form
+        id="authn_select"
+        class={kcClsx('kcFormClass')}
+      >
+        {#each authenticators.authenticators as authenticator (authenticator.credentialId)}
+          <input
+            type="hidden"
+            name="authn_use_chk"
+            readOnly
+            value={authenticator.credentialId}
+          />
+        {/each}
+      </form>
+    {/if}
+    <br />
+
+    <input
+      id={webAuthnButtonId}
+      type="button"
+      class={kcClsx('kcButtonClass', 'kcButtonDefaultClass', 'kcButtonBlockClass', 'kcButtonLargeClass')}
+      value={msgStr('passkey-doAuthenticate')}
+    />
+  {/if}
 </Template>

--- a/src/login/pages/Login.useScript.ts
+++ b/src/login/pages/Login.useScript.ts
@@ -1,0 +1,84 @@
+import { useInsertScriptTags } from '@keycloakify/svelte/tools/useInsertScriptTags';
+import { assert } from 'keycloakify/tools/assert';
+import { waitForElementMountedOnDom } from 'keycloakify/tools/waitForElementMountedOnDom';
+import { onMount } from 'svelte';
+import type { Readable } from 'svelte/store';
+import type { KcContext } from '../KcContext';
+
+type KcContextLike = {
+  url: {
+    resourcesPath: string;
+  };
+  isUserIdentified: boolean | 'true' | 'false';
+  challenge: string;
+  userVerification: string;
+  rpId: string;
+  createTimeout: number | string;
+  enableWebAuthnConditionalUI?: boolean;
+};
+
+assert<keyof KcContextLike extends keyof KcContext.Login ? true : false>();
+assert<KcContext.Login extends KcContextLike ? true : false>();
+
+type I18nLike = {
+  msgStr: (key: 'webauthn-unsupported-browser-text' | 'passkey-unsupported-browser-text') => string;
+  isFetchingTranslations: boolean;
+};
+
+export function useScript(params: { webAuthnButtonId: string; kcContext: KcContextLike; i18n: Readable<I18nLike> }) {
+  const { webAuthnButtonId, kcContext, i18n } = params;
+
+  const { url, isUserIdentified, challenge, userVerification, rpId, createTimeout } = kcContext;
+
+  onMount(() => {
+    const unsubscribe = i18n.subscribe(($i18n) => {
+      const { msgStr, isFetchingTranslations } = $i18n;
+
+      const { insertScriptTags } = useInsertScriptTags({
+        componentOrHookName: 'Login',
+        scriptTags: [
+          {
+            type: 'module',
+            textContent: () => `
+                    import { authenticateByWebAuthn } from "${url.resourcesPath}/js/webauthnAuthenticate.js";
+                    import { initAuthenticate } from "${url.resourcesPath}/js/passkeysConditionalAuth.js";
+
+                    const authButton = document.getElementById("${webAuthnButtonId}");
+                    const input = {
+                        isUserIdentified : ${isUserIdentified},
+                        challenge : ${JSON.stringify(challenge)},
+                        userVerification : ${JSON.stringify(userVerification)},
+                        rpId : ${JSON.stringify(rpId)},
+                        createTimeout : ${createTimeout}
+                    };
+                    authButton.addEventListener("click", () => {
+                        authenticateByWebAuthn({
+                            ...input,
+                            errmsg : ${JSON.stringify(msgStr('webauthn-unsupported-browser-text'))}
+                        });
+                    }, { once: true });
+
+                    initAuthenticate({
+                        ...input,
+                        errmsg : ${JSON.stringify(msgStr('passkey-unsupported-browser-text'))}
+                    });
+                `,
+          },
+        ],
+      });
+
+      if (isFetchingTranslations || kcContext.enableWebAuthnConditionalUI !== true) {
+        return;
+      }
+
+      (async () => {
+        await waitForElementMountedOnDom({
+          elementId: webAuthnButtonId,
+        });
+
+        insertScriptTags();
+      })();
+    });
+    return () => unsubscribe();
+  });
+}

--- a/stories/login/pages/Login.stories.svelte
+++ b/stories/login/pages/Login.stories.svelte
@@ -16,6 +16,27 @@
 
 <Story name="Default" />
 
+<!--
+  Passkeys via WebAuthn conditional UI. Keycloak only sends these fields when the realm
+  offers passkeys on login.ftl; mocking them here is the only way to see the branch
+  without a fully configured realm. Expect autocomplete="username webauthn" on the
+  username input and a hidden #webauth form at the end of the page.
+-->
+<Story
+  name="WithPasskeyConditionalUI"
+  args={{
+    ...args,
+    kcContext: {
+      enableWebAuthnConditionalUI: true,
+      isUserIdentified: 'false',
+      challenge: 'P9OnaFRxQv-PJxt9CUPwbg',
+      userVerification: 'preferred',
+      rpId: 'localhost',
+      createTimeout: 0,
+    },
+  }}
+/>
+
 <!--  -->
 <Story
   name="WithInvalidCredential"


### PR DESCRIPTION
Closes #18.

`Login.svelte` didn't implement the WebAuthn conditional UI (passkey autofill) that Keycloak offers on `login.ftl`, even though the React flavour of `keycloakify` already has it. This ports the three missing pieces from `keycloakify`'s `Login.tsx` / `Login.useScript.tsx`:

1. **`Login.useScript.ts`** — loads `passkeysConditionalAuth.js` / `webauthnAuthenticate.js` and wires up `initAuthenticate()` (autofill) and the passkey button's `authenticateByWebAuthn()` click handler, gated on `kcContext.enableWebAuthnConditionalUI`. Mirrors the pattern already used by `LoginPasskeysConditionalAuthenticate.useScript.ts` in this repo.
2. **`autocomplete="username webauthn"`** on the username input when conditional UI is enabled (was hardcoded to `"username"`), which is what lets the browser attach passkey autofill to the field in the first place.
3. **Hidden `#webauth` form** (`clientDataJSON`/`authenticatorData`/`signature`/`credentialId`/`userHandle`/`error`) plus the authenticator list and passkey button, rendered when `enableWebAuthnConditionalUI` is true — this is where Keycloak's `webauthnAuthenticate.js` `returnSuccess()` writes the assertion before submitting.

Both pieces fail silently when missing (no console error), which is why it was easy to miss originally — see the issue for details.

Also adds a `WithPasskeyConditionalUI` story to `Login.stories.svelte` that mocks `enableWebAuthnConditionalUI` and the other WebAuthn fields, since Keycloak only sends them when the realm actually offers passkeys — this is the only way to see/review the branch without a fully configured realm.

Verified with `svelte-check`, `format --list-different`, `eslint`, and `npm run build`, all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added passkey authentication support to the login page.
  * Enabled conditional WebAuthn UI, including browser autofill and available-authenticator selection.
  * Added hidden fields to support passkey sign-in submissions.

* **Tests**
  * Added coverage for login experiences with conditional passkey authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->